### PR TITLE
impl surge marshalling and test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/renproject/secp256k1-go
 go 1.12
 
 require (
-	github.com/onsi/ginkgo v1.8.0
-	github.com/onsi/gomega v1.5.0
+	github.com/onsi/ginkgo v1.11.0
+	github.com/onsi/gomega v1.8.1
+	github.com/renproject/surge v1.1.2
 )

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,14 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0 h1:VkHVNpR4iVnU8XQR6DBm8BqYjN7CRzw+xKUbVVbbW9w=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.11.0 h1:JAKSXpt1YjtLA7YpPiqO9ss6sNXEsPfSGdwN0UHqzrw=
+github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/onsi/gomega v1.8.1 h1:C5Dqfs/LeauYDX0jJXIe2SWmwCbGzx9yF8C8xy3Lh34=
+github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
+github.com/renproject/surge v1.1.2 h1:Yy3pTlRyaMJGLfn64JHgCnWs3cWbRJjE+aFxZXRGfWU=
+github.com/renproject/surge v1.1.2/go.mod h1:UnnFYpLSD0T9MzCcyHjbNdmxiQsDVyBDCuqcbhcaLCY=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd h1:nTDtHvHSdCn1m6ITfMRqtOd/9+7a3s8RBNOZ3eYZzJA=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -14,6 +20,8 @@ golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e h1:o3PsSEY8E4eXWkXrIP9YJALUk
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
@@ -21,3 +29,5 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkep
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
+gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/secp256k1_test.go
+++ b/secp256k1_test.go
@@ -1,7 +1,9 @@
 package secp256k1_test
 
 import (
+	"bytes"
 	"math/big"
+	"math/rand"
 	"testing/quick"
 
 	. "github.com/onsi/ginkgo"
@@ -590,6 +592,59 @@ var _ = Describe("Wrapped field elements", func() {
 				return z.Uint64() == y.Uint64()
 			}, nil)
 			Expect(err).To(BeNil())
+		})
+	})
+
+	//
+	// Marshalling
+	//
+
+	Context("Marshalling elements in Fn", func() {
+		trials := 1000
+
+		var a, b secp256k1.Secp256k1N
+		var bs [32]byte
+
+		buf := bytes.NewBuffer(bs[:0])
+
+		It("should be the same after marshalling and unmarshalling", func() {
+			for i := 0; i < trials; i++ {
+				buf.Reset()
+				a = secp256k1.RandomSecp256k1N()
+
+				m, err := a.Marshal(buf, 32)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(m).To(Equal(0))
+
+				m, err = b.Unmarshal(buf, 32)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(m).To(Equal(0))
+
+				Expect(a.Eq(&b)).To(BeTrue())
+			}
+		})
+
+		It("should return an error if the max bytes are exceeded when marshalling", func() {
+			for i := 0; i < trials; i++ {
+				buf.Reset()
+				a = secp256k1.RandomSecp256k1N()
+				max := rand.Intn(32)
+
+				m, err := a.Marshal(buf, max)
+				Expect(err).To(HaveOccurred())
+				Expect(m).To(Equal(max))
+			}
+		})
+
+		It("should return an error if the max bytes are exceeded when unmarshalling", func() {
+			for i := 0; i < trials; i++ {
+				buf.Reset()
+				max := rand.Intn(32)
+
+				m, err := a.Unmarshal(buf, max)
+				Expect(err).To(HaveOccurred())
+				Expect(m).To(Equal(max))
+			}
 		})
 	})
 })


### PR DESCRIPTION
This PR implements the `surge.Marhsaler` and `surge.Unmarshaler` interfaces for the `Secp256k1N` type. This will allow easier marshaling for types that contain this type.